### PR TITLE
cleaner patch - updated master makefile for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ sodium: sodium-configure
 	$(MAKE) -C $(SODIUM_BUILD) install CFLAGS=-fPIC
 
 build: ensure sodium
-	cd $(BUILD_DIR) && cmake $(LLARPD_SRC) -DSODIUM_LIBRARIES=$(SODIUM_LIB) -DSODIUM_INCLUDE_DIR=$(DEP_PREFIX)/include
+	cd $(BUILD_DIR) && cmake $(LLARPD_SRC) -DSODIUM_LIBRARIES=$(SODIUM_LIB) -DSODIUM_INCLUDE_DIR=$(DEP_PREFIX)/include -G "Unix Makefiles"
 	$(MAKE) -C $(BUILD_DIR)
 	cp $(BUILD_DIR)/llarpd $(EXE)
 


### PR DESCRIPTION
this forces CMake on all platforms to use `[g]make`; on windows, the default project generator is Microsoft C++ (Incidentally, this also happens to fix 32-bit builds, the `windows*` targets were 64-bit specific 😁)